### PR TITLE
lib: Add Windows to allow-list of supported platforms

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -19,7 +19,7 @@ class ClangdClient extends AutoLanguageClient {
   startServerProcess (projectPath) {
     const config = atom.config.get(PACKAGE_NAME);
 
-    const platform = { 'linux': 'linux', 'darwin': 'mac' }[process.platform];
+    const platform = { 'linux': 'linux', 'darwin': 'mac', 'win32': 'windows' }[process.platform];
     if (platform == null) {
       throw Error (`${this.getServerName()} not supported on ${process.platform}`);
     }


### PR DESCRIPTION
### Context

Clangd is, in fact, supported on Windows!

See: https://clangd.llvm.org/installation#installing-clangd and https://github.com/clangd/clangd/releases/latest

### Issue this solves

Without this change, Windows users get an error like this in the Pulsar console: `Error: Clangd not supported on win32`.

<details><summary>Error message (click to expand):</summary>

```
C:\Users\User\.pulsar\packages\pulsar-ide-clangd\lib\main.js:25 Uncaught (in promise) Error: Clangd not supported on win32
    at ClangdClient.startServerProcess (C:\Users\User\.pulsar\packages\pulsar-ide-clangd\lib\main.js:25)
    at ClangdClient.<anonymous> (auto-languageclient.ts:527)
    at Generator.next (<anonymous>)
    at C:\Users\User\.pulsar\packages\pulsar-ide-clangd\node_modules\@savetheclocktower\atom-languageclient\build\lib\auto-languageclient.js:31
    at new Promise (<anonymous>)
    at __awaiter (C:\Users\User\.pulsar\packages\pulsar-ide-clangd\node_modules\@savetheclocktower\atom-languageclient\build\lib\auto-languageclient.js:27)
    at auto-languageclient.ts:527
    at ClangdClient.<anonymous> (auto-languageclient.ts:1464)
    at Generator.next (<anonymous>)
    at C:\Users\User\.pulsar\packages\pulsar-ide-clangd\node_modules\@savetheclocktower\atom-languageclient\build\lib\auto-languageclient.js:31
    at new Promise (<anonymous>)
    at __awaiter (C:\Users\User\.pulsar\packages\pulsar-ide-clangd\node_modules\@savetheclocktower\atom-languageclient\build\lib\auto-languageclient.js:27)
    at ClangdClient.AutoLanguageClient.reportBusyWhileDefault (auto-languageclient.ts:1460)
    at ClangdClient.AutoLanguageClient.reportBusyWhile (auto-languageclient.ts:1456)
    at ClangdClient.<anonymous> (auto-languageclient.ts:524)
    at Generator.next (<anonymous>)
    at C:\Users\User\.pulsar\packages\pulsar-ide-clangd\node_modules\@savetheclocktower\atom-languageclient\build\lib\auto-languageclient.js:31
    at new Promise (<anonymous>)
    at __awaiter (C:\Users\User\.pulsar\packages\pulsar-ide-clangd\node_modules\@savetheclocktower\atom-languageclient\build\lib\auto-languageclient.js:27)
    at ClangdClient.startServer (auto-languageclient.ts:523)
    at ServerManager._startServer (auto-languageclient.ts:432)
    at ServerManager.<anonymous> (server-manager.ts:150)
    at Generator.next (<anonymous>)
    at C:\Users\User\.pulsar\packages\pulsar-ide-clangd\node_modules\@savetheclocktower\atom-languageclient\build\lib\server-manager.js:31
    at new Promise (<anonymous>)
    at __awaiter (C:\Users\User\.pulsar\packages\pulsar-ide-clangd\node_modules\@savetheclocktower\atom-languageclient\build\lib\server-manager.js:27)
    at ServerManager.startServer (server-manager.ts:148)
    at ServerManager.<anonymous> (server-manager.ts:145)
    at Generator.next (<anonymous>)
    at C:\Users\User\.pulsar\packages\pulsar-ide-clangd\node_modules\@savetheclocktower\atom-languageclient\build\lib\server-manager.js:31
startServerProcess @ C:\Users\User\.pulsar\packages\pulsar-ide-clangd\lib\main.js:25
(anonymous) @ auto-languageclient.ts:527
(anonymous) @ C:\Users\User\.pulsar\packages\pulsar-ide-clangd\node_modules\@savetheclocktower\atom-languageclient\build\lib\auto-languageclient.js:31
__awaiter @ C:\Users\User\.pulsar\packages\pulsar-ide-clangd\node_modules\@savetheclocktower\atom-languageclient\build\lib\auto-languageclient.js:27
(anonymous) @ auto-languageclient.ts:527
(anonymous) @ auto-languageclient.ts:1464
(anonymous) @ C:\Users\User\.pulsar\packages\pulsar-ide-clangd\node_modules\@savetheclocktower\atom-languageclient\build\lib\auto-languageclient.js:31
__awaiter @ C:\Users\User\.pulsar\packages\pulsar-ide-clangd\node_modules\@savetheclocktower\atom-languageclient\build\lib\auto-languageclient.js:27
AutoLanguageClient.reportBusyWhileDefault @ auto-languageclient.ts:1460
AutoLanguageClient.reportBusyWhile @ auto-languageclient.ts:1456
(anonymous) @ auto-languageclient.ts:524
(anonymous) @ C:\Users\User\.pulsar\packages\pulsar-ide-clangd\node_modules\@savetheclocktower\atom-languageclient\build\lib\auto-languageclient.js:31
__awaiter @ C:\Users\User\.pulsar\packages\pulsar-ide-clangd\node_modules\@savetheclocktower\atom-languageclient\build\lib\auto-languageclient.js:27
startServer @ auto-languageclient.ts:523
(anonymous) @ auto-languageclient.ts:432
(anonymous) @ server-manager.ts:150
(anonymous) @ C:\Users\User\.pulsar\packages\pulsar-ide-clangd\node_modules\@savetheclocktower\atom-languageclient\build\lib\server-manager.js:31
__awaiter @ C:\Users\User\.pulsar\packages\pulsar-ide-clangd\node_modules\@savetheclocktower\atom-languageclient\build\lib\server-manager.js:27
startServer @ server-manager.ts:148
(anonymous) @ server-manager.ts:145
(anonymous) @ C:\Users\User\.pulsar\packages\pulsar-ide-clangd\node_modules\@savetheclocktower\atom-languageclient\build\lib\server-manager.js:31
__awaiter @ C:\Users\User\.pulsar\packages\pulsar-ide-clangd\node_modules\@savetheclocktower\atom-languageclient\build\lib\server-manager.js:27
getServer @ server-manager.ts:126
(anonymous) @ server-manager.ts:89
(anonymous) @ C:\Users\User\.pulsar\packages\pulsar-ide-clangd\node_modules\@savetheclocktower\atom-languageclient\build\lib\server-manager.js:31
__awaiter @ C:\Users\User\.pulsar\packages\pulsar-ide-clangd\node_modules\@savetheclocktower\atom-languageclient\build\lib\server-manager.js:27
_handleTextEditor @ server-manager.ts:86
_handleGrammarChange @ server-manager.ts:106
(anonymous) @ server-manager.ts:80
observeGrammar @ C:\Users\User\Downloads\Windows.Pulsar-1.113.0-win\resources\app.asar\src\text-editor.js:1008
observeTextEditors @ server-manager.ts:80
observe @ C:\Users\User\AppData\Local\Programs\Pulsar\resources\app.asar\src\text-editor-registry.js:147
startListening @ server-manager.ts:62
activate @ auto-languageclient.ts:441
activateNow @ C:\Users\User\AppData\Local\Programs\Pulsar\resources\app.asar\src\package.js:242
(anonymous) @ C:\Users\User\AppData\Local\Programs\Pulsar\resources\app.asar\src\package.js:1067
simpleDispatch @ C:\Users\User\Downloads\Windows.Pulsar-1.113.0-win\resources\app.asar\node_modules\event-kit\dist\emitter.js:64
emit @ C:\Users\User\Downloads\Windows.Pulsar-1.113.0-win\resources\app.asar\node_modules\event-kit\dist\emitter.js:257
triggerDeferredActivationHooks @ C:\Users\User\AppData\Local\Programs\Pulsar\resources\app.asar\src\package-manager.js:804
(anonymous) @ C:\Users\User\AppData\Local\Programs\Pulsar\resources\app.asar\src\package-manager.js:733
Promise.then (async)
step @ C:\Users\User\.pulsar\packages\pulsar-ide-clangd\node_modules\@savetheclocktower\atom-languageclient\build\lib\server-manager.js:30
(anonymous) @ C:\Users\User\.pulsar\packages\pulsar-ide-clangd\node_modules\@savetheclocktower\atom-languageclient\build\lib\server-manager.js:31
__awaiter @ C:\Users\User\.pulsar\packages\pulsar-ide-clangd\node_modules\@savetheclocktower\atom-languageclient\build\lib\server-manager.js:27
_handleTextEditor @ server-manager.ts:86
_handleGrammarChange @ server-manager.ts:106
(anonymous) @ server-manager.ts:80
observeGrammar @ C:\Users\User\Downloads\Windows.Pulsar-1.113.0-win\resources\app.asar\src\text-editor.js:1008
observeTextEditors @ server-manager.ts:80
observe @ C:\Users\User\AppData\Local\Programs\Pulsar\resources\app.asar\src\text-editor-registry.js:147
startListening @ server-manager.ts:62
activate @ auto-languageclient.ts:441
activateNow @ C:\Users\User\AppData\Local\Programs\Pulsar\resources\app.asar\src\package.js:242
(anonymous) @ C:\Users\User\AppData\Local\Programs\Pulsar\resources\app.asar\src\package.js:1067
simpleDispatch @ C:\Users\User\Downloads\Windows.Pulsar-1.113.0-win\resources\app.asar\node_modules\event-kit\dist\emitter.js:64
emit @ C:\Users\User\Downloads\Windows.Pulsar-1.113.0-win\resources\app.asar\node_modules\event-kit\dist\emitter.js:257
triggerDeferredActivationHooks @ C:\Users\User\AppData\Local\Programs\Pulsar\resources\app.asar\src\package-manager.js:804
(anonymous) @ C:\Users\User\AppData\Local\Programs\Pulsar\resources\app.asar\src\package-manager.js:733
Promise.then (async)
activate @ C:\Users\User\AppData\Local\Programs\Pulsar\resources\app.asar\src\package-manager.js:732
(anonymous) @ C:\Users\User\AppData\Local\Programs\Pulsar\resources\app.asar\src\atom-environment.js:1044
async function (async)
(anonymous) @ C:\Users\User\AppData\Local\Programs\Pulsar\resources\app.asar\src\atom-environment.js:921
Promise.then (async)
startEditorWindow @ C:\Users\User\AppData\Local\Programs\Pulsar\resources\app.asar\src\atom-environment.js:915
module.exports @ C:\Users\User\AppData\Local\Programs\Pulsar\resources\app.asar\src\initialize-application-window.js:53
setupWindow @ index.js:120
window.onload @ index.js:60
async function (async)
window.onload @ index.js:26
load (async)
(anonymous) @ index.js:22
(anonymous) @ index.js:162
```

</details>

### Change

This PR adds Windows (NodeJS `'win32'`) to the set of allowed platforms as detected from `process.platform`, alongside macOS (`'darwin'`) and Linux (`'linux'`).

### Verification

I confirm this allows the package to work on Windows, doing things like "**Symbols View: Go To Declaration**" when using this package in Pulsar on Windows. (Manually tested.)